### PR TITLE
Fixes for node engine and express version limits

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+0.5.3 / 2012-04-16
+==================
+
+  * Fixed bug with minimum node version for previous changes that require node 0.6.1 or higher
+  * Added limitation to express version installed < 3.0 as this is in alpha and breaks timbits 
+
 0.5.2 / 2012-04-12
 ==================
 

--- a/package.json
+++ b/package.json
@@ -10,22 +10,22 @@
 		{ "name": "Kevin Gamble", "email": "kgamble@postmedia.com" }
 	],
 	"dependencies": {
-		"coffee-script": ">= 1.2.0",
-		"coffeekup": ">= 0.3.1",
-		"coloured-log": ">= 0.9.7",
+		"coffee-script": "1.2.x",
+		"coffeekup": "0.3.x",
+		"coloured-log": "0.9.x",
 		"connect-assets": "= 2.0.0-rc1",
 		"connect-esi": ">= 0.1.7",
-		"connect-less": ">= 0.2.3",
-		"express": ">= 2.5.6 < 3.0",
-		"jsonp-filter": ">= 0.0.2",
+		"connect-less": "0.2.x",
+		"express": "2.x.x",
+		"jsonp-filter": "0.0.x",
 		"pantry": ">= 0.3.0",
-		"request": ">= 2.9.1",
-		"optimist": ">= 0.2.6",
-		"run": ">= 0.2.3"
+		"request": "2.9.x",
+		"optimist": "0.2.x",
+		"run": "0.2.x"
 	},
 	"devDependencies": {
-		"vows": ">= 0.6.1",
-		"request": ">= 2.9.100"
+		"vows": "0.6.x",
+		"request": "2.9.x"
 	},
 	"bugs": { "url": "https://github.com/Postmedia/timbits/issues"},
 	"licenses": [
@@ -40,5 +40,5 @@
 	"scripts": {
 		"build": "cake build"
 	},
-	"engines": { "node": ">= 0.6.1" }
+	"engines": { "node": "0.6.x" }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "timbits",
 	"description": "Widget framework based on Express and CoffeeScript",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"homepage": "https://github.com/Postmedia/timbits",
 	"author": "Edward de Groot <edegroot@postmedia.com> (http://mred9.wordpress.com)",
 	"contributors": [ 
@@ -16,7 +16,7 @@
 		"connect-assets": "= 2.0.0-rc1",
 		"connect-esi": ">= 0.1.7",
 		"connect-less": ">= 0.2.3",
-		"express": ">= 2.5.6",
+		"express": ">= 2.5.6 < 3.0",
 		"jsonp-filter": ">= 0.0.2",
 		"pantry": ">= 0.3.0",
 		"request": ">= 2.9.1",
@@ -40,5 +40,5 @@
 	"scripts": {
 		"build": "cake build"
 	},
-	"engines": { "node": ">= 0.4.5" }
+	"engines": { "node": ">= 0.6.1" }
 }


### PR DESCRIPTION
Just need to review , verified heroku as third party supports and used the following versions of node:

0.6.14
0.6.13
0.6.12
0.6.11
0.6.10
0.6.8
0.6.7
0.6.6
0.6.5
0.6.3
0.4.10
0.4.7

pulled from: http://heroku-buildpack-nodejs.s3.amazonaws.com/manifest.nodejs
