### PR TITLE
added default value to prompt for override, colorized prompt/help

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+0.6.2 /2012-10-17
+=================
+
+  * Add override option to pass custom values to mocha test engine
+
+
 0.6.1 / 2012-10-16
 ==================
 

--- a/README.md
+++ b/README.md
@@ -226,9 +226,11 @@ If you use the test cases provided by the timbit new project template, you can a
 	
 Running the test command will invoke the mocha test framework.  The command will also load up any environment variables found in the optional .env file before starting the server and running the tests.
 
-Just as with running tests via the browser, you can indicate you want to run through all the available tests via the --all flag.  In addition, you can tell mocha to watch for file changes and retest via the --watch flag.
+Just as with running tests via the browser, you can indicate you want to run through all the available tests via the -all flag.  In addition, you can tell mocha to watch for file changes and retest via the -watch flag.
 
-In case the default test engine commands do not suit your needs, you can override these with the --override flag.  By default we pass the following into mocha for running the tests: --reporter spec --compilers coffee:coffee-script --growl --colors
+In case the default test engine commands do not suit your needs, you can override these with the -override flag.  By default we pass the following into mocha for running the tests: --reporter spec --compilers coffee:coffee-script --growl --colors
+
+For a list of mocha test options please refer to http://visionmedia.github.com/mocha/
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -228,13 +228,15 @@ Running the test command will invoke the mocha test framework.  The command will
 
 Just as with running tests via the browser, you can indicate you want to run through all the available tests via the --all flag.  In addition, you can tell mocha to watch for file changes and retest via the --watch flag.
 
+In case the default test engine commands do not suit your needs, you can override these with the --override flag.  By default we pass the following into mocha for running the tests: --reporter spec --compilers coffee:coffee-script --growl --colors
+
 Example:
 
-	timbits test --all --watch
+	timbits test -all -watch -override
 	
 Or (if you want to minimize typing)
 
-	timbits t -aw
+	timbits t -awo
 
 ### Default view
 

--- a/bin/timbits
+++ b/bin/timbits
@@ -7,6 +7,7 @@ optimist = require 'optimist'
 Log = require 'coloured-log'
 log = new Log()
 which = require('which').sync
+readline = require 'readline'
 
 optimist.usage("\nTimbits Code Generation\n\n" +
 "timbits n[ew] [project]\n\tCreates new subfolders [project], [project]/timbits, and [project]/views.\n\tGenerates basic server.js, package.json, History.md, README.md, and LICENSE files.\n\n" +
@@ -18,6 +19,7 @@ optimist.usage("\nTimbits Code Generation\n\n" +
 
 optimist.alias('a', 'all').describe('a', 'run all dynamic tests')
 optimist.alias('w', 'watch').describe('w', 'watch for changes and retest')
+optimist.alias('o', 'override').describe('o', 'override test engine options')
 
 lib = path.dirname(fs.realpathSync(__filename)) + '/template'
 
@@ -95,19 +97,28 @@ startServer = (filename) ->
 	cmd = which('runjs')
 	runjs = spawn(cmd, [ filename ], {stdio: 'inherit', env: process.env})
 
-runTests = (alltests, watch) ->
+runTests = (alltests, watch, override) ->
 	process.env.TIMBITS_TEST_WHICH = 'all' if alltests
 	loadEnv()
+	args = []
+	defaultArgs = "--reporter spec --compilers coffee:coffee-script --growl --colors"
 	
-	args = [
-		'--reporter'
-		'spec'
-		'--compilers'
-		'coffee:coffee-script'
-		'--growl'
-		'--colors'
-		]
+	if override
+		ask = readline.createInterface(process.stdin, process.stdout, null)
+		log.notice "Override of test enging options"
+		console.log "\u001b[33mPlease refer to the mocha documentation for available options, default options provided below.\n"
+		ask.question "\u001b[34mPlease enter test options: \u001b[0m", (answer) ->
+			log.notice "Running test engine with: #{answer}"
+			ask.close()
+			process.stdin.destroy
+			args = answer.split(' ')
+			runMocha args, watch
+		ask.write "--reporter spec --compilers coffee:coffee-script --growl --colors"
+	else
+		args = defaultArgs.split(' ')
+		runMocha args, watch
 
+runMocha = (args, watch) ->
 	args.push '--watch' if watch
 
 	cmd = which('mocha')
@@ -152,7 +163,7 @@ switch optimist.argv._[0]
 		startServer(filename)
 		
 	when 't', 'test'
-		runTests(optimist.argv.a, optimist.argv.w)
+		runTests(optimist.argv.a, optimist.argv.w, optimist.argv.o)
 		
 	when 'v', 'version'
 		showVersion()

--- a/bin/timbits
+++ b/bin/timbits
@@ -106,8 +106,8 @@ runTests = (alltests, watch, override) ->
 	if override
 		ask = readline.createInterface(process.stdin, process.stdout, null)
 		log.notice "Override of test enging options"
-		console.log "\u001b[33mPlease refer to the mocha documentation for available options, default options provided below.\n"
-		ask.question "\u001b[34mPlease enter test options: \u001b[0m", (answer) ->
+		console.log "\u001b[33mPlease refer to the mocha documentation for available options, default options provided below. \u001b[0m\n"
+		ask.question "Please enter test options:", (answer) ->
 			log.notice "Running test engine with: #{answer}"
 			ask.close()
 			process.stdin.destroy

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "timbits",
 	"description": "Widget framework based on Express and CoffeeScript",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"homepage": "https://github.com/Postmedia/timbits",
 	"author": "Edward de Groot <edegroot@postmedia.com> (http://mred9.wordpress.com)",
 	"contributors": [ 


### PR DESCRIPTION
Ed,

Take a look at my solution here for allowing the test engine override.  Essentially using the readline lib to prompt for options when -o (-override) flag is passed.

Prompt displays our current defaults allowing user to hit enter to just accept, or to modify/append.
